### PR TITLE
Updates for v14.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ or zero downtime rolling updates.
 
 This appliance includes all the standard features in `TurnKey Core`_, and on top of that:
 
-- Latest stable release of Ansible (currently v1.9.2)
+- Stable release of Ansible v1.9.4
 - Ansible installed via pip
 - Sudo support for the ansible user.
 - SSL support out of the box.

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ For examples of how to use the Ansible appliance, see `Usage`_.
 
 Documentation
 -------------
-- See the latest documentation at http://docs.ansible.com
+- See the latest documentation at http://docs.ansible.com/ansible/
 - https://github.com/ansible
 - http://jpmens.net/2012/06/06/configuration-management-with-ansible/
 - http://devopsu.com/guides/ansible-ubuntu-debian.html

--- a/changelog
+++ b/changelog
@@ -1,4 +1,8 @@
-turnkey-ansible-14.0 (1) turnkey; urgency=low
+turnkey-ansible-14.1 (1) turnkey; urgency=low
+
+  * Ansible version 1.9.4
+
+ -- John Carver <dude4linux@gmail.com>  Tue Jan 19 23:33:37 UTC 2016
 
   * Initial release of appliance.
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # install ansible
-pip install ansible --upgrade
+pip install 'ansible==1.9.4'
 
 ANSIBLE_USER=ansible
 ANSIBLE_PASS=turnkey

--- a/conf.d/main
+++ b/conf.d/main
@@ -1,5 +1,11 @@
 #!/bin/bash -ex
 
+# install setuptools
+python -m pip install --upgrade --force setuptools
+
+# upgrade pip
+python -m pip install --upgrade --force pip
+
 # install ansible
 pip install 'ansible==1.9.4'
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -97,11 +97,11 @@ You should now be able to run plays and playbooks without needing to prompt for 
 
 Documentation
 -------------
-- See the latest documentation at http://docs.ansible.com
+- See the latest documentation at http://docs.ansible.com/ansible/
 - https://github.com/ansible
 - http://jpmens.net/2012/06/06/configuration-management-with-ansible/
 - http://devopsu.com/guides/ansible-ubuntu-debian.html
 - https://github.com/fourkitchens/server-playbooks
 
 
-.. _Ansible: http://docs.ansible.com
+.. _Ansible: http://docs.ansible.com/ansible/

--- a/overlay/etc/ansible/ansible.cfg
+++ b/overlay/etc/ansible/ansible.cfg
@@ -1,5 +1,5 @@
-# config file for ansible -- http://ansible.com/
-# ==============================================
+# config file for ansible -- http://docs.ansible.com/ansible/intro_configuration.html
+# ===================================================================================
 
 # nearly all parameters can be overridden in ansible-playbook 
 # or with command line flags. ansible will read ANSIBLE_CONFIG,

--- a/overlay/etc/ansible/ansible.cfg
+++ b/overlay/etc/ansible/ansible.cfg
@@ -63,7 +63,7 @@ timeout = 10
 # use this shell for commands executed under sudo
 # you may need to change this to bin/bash in rare instances
 # if sudo is constrained
-executable = /bin/bash
+#executable = /bin/sh
 
 # if inventory variables overlap, does the higher precedence one win
 # or are hash values merged together?  The default is 'replace' but

--- a/overlay/etc/ansible/hosts
+++ b/overlay/etc/ansible/hosts
@@ -1,6 +1,6 @@
 # Ansible hosts
 # See /etc/ansible/hosts.example or
-# the on-line documentation at http://docs.ansible.com/intro_inventory.html
+# the on-line documentation at http://docs.ansible.com/ansible/intro_inventory.html
 # for information on how to configure this file.
 
 ansible               ansible_connection=local

--- a/plan/main
+++ b/plan/main
@@ -5,9 +5,6 @@ python-pip
 
 libyaml-0-2         /* packages needed for yaml parsing */
 libyaml-dev
-gcc                 /* packages needed for compiling pycrypto */
-make
-python-dev
 python-apt          /* allows ansible to manage apt packages */
 sudo                /* required to give ansible user root privileges */
 sshpass             /* required by ansible to script password entry */

--- a/plan/main
+++ b/plan/main
@@ -9,7 +9,6 @@ gcc                 /* packages needed for compiling pycrypto */
 make
 python-dev
 python-apt          /* allows ansible to manage apt packages */
-python-setuptools   /* required for installing pip */
 sudo                /* required to give ansible user root privileges */
 sshpass             /* required by ansible to script password entry */
 keychain            /* manages ssh-agent keys for ansible */


### PR DESCRIPTION
Peg Ansible version at 1.9.4.  Latest stable version is 2.0.0.2, but it appears to have some problems.
Removed an unnecessary package, python-setuptools.
Reverted the default shell to /bin/sh.  Setting it to /bin/bash caused problems with ansible 2.0.
Updated the README and changelog for versions 1.9.4 and v14.1.
