### PR TITLE
Updates for 15.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-Ansible - Radically simple IT automation platform
-=================================================
+Ansible® - Radically simple IT automation platform
+==================================================
 
 `Ansible`_ is a simple, agentless IT automation engine that automates
 cloud provisioning, configuration management, application deployment and
@@ -9,8 +9,9 @@ downtime rolling updates.
 
 This appliance includes all the standard features in `TurnKey Core`_, and on top of that:
 
-- Stable release of Ansible v2.3.0
-- Ansible installed via pip
+- Stable release of Ansible 2.5.0
+- WinRM support for managing Windows hosts.
+- Ansible installed via pip.
 - Sudo support for the ansible user.
 - SSL support out of the box.
 - Webmin modules for managing and configuring server.
@@ -28,7 +29,9 @@ Resources
 - `Configuration management with Ansible <http://jpmens.net/2012/06/06/configuration-management-with-ansible/>`_
 - `Ansible playbooks for use in setting up servers <https://github.com/fourkitchens/server-playbooks>`_
 
-Note: this software appliance is not supported by Ansible or Red Hat
+Ansible® is a registered trademark of Ansible, Inc. in the United States and other countries.
+
+Note: This software appliance is not supported by Ansible or Red Hat
 
 Credentials *(passwords set at first boot)*
 -------------------------------------------

--- a/changelog
+++ b/changelog
@@ -1,6 +1,6 @@
 turnkey-ansible-15.0 (1) turnkey; urgency=low
 
-  * Ansible version 2.4.3
+  * Ansible version 2.5.0
 
   * Fixed #935 - Issues with Ansible launched via the Hub/AWS.
 

--- a/changelog
+++ b/changelog
@@ -4,10 +4,12 @@ turnkey-ansible-15.0 (1) turnkey; urgency=low
 
   * Fixed #935 - Issues with Ansible launched via the Hub/AWS.
 
+  * Added Ansible® Trademark statement.
+
   * Note: Please refer to turnkey-core's changelog for changes common to all
     appliances. Here we only describe changes specdific to this appliance.
 
- -- Stefan Davis <stefan@turnkeylinux.org>  Wed, 07 Mar 2018 21:51:10 +1100
+ -- John Carver <dude4linux@gmail.com>  Wed, 04 Apr 2018 14:26:47 +0000
 
 turnkey-ansible-14.2 (1) turnkey; urgency=low
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -8,7 +8,7 @@ HTDOCS=/var/www/ansible/htdocs
 # install ansible and deps (inc Windows support)
 easy_install pip
 python -m pip install --upgrade --force setuptools
-pip install 'ansible==2.4.3.0'
+pip install 'ansible==2.5.0.0'
 pip install --upgrade 'pywinrm>=0.1.1'
 
 # configure default new user skel dir to be /etc/skel-ansible

--- a/conf.d/main
+++ b/conf.d/main
@@ -11,17 +11,15 @@ python -m pip install --upgrade --force setuptools
 pip install 'ansible==2.5.0.0'
 pip install --upgrade 'pywinrm>=0.1.1'
 
-# configure default new user skel dir to be /etc/skel-ansible
-CONF=/etc/default/useradd
-sed -i "/SKEL=/ {s|^# ||; s|/etc/skel.*|/etc/skel-${ADMIN_USER}|}" $CONF
-cp -r /etc/skel/. /etc/skel-${ADMIN_USER}
-
 # create admins group, ansible user and sudo privs
 addgroup --system admins
 adduser --disabled-login --gecos 'ansible user' $ADMIN_USER
 echo $ADMIN_USER:$ADMIN_PASS | chpasswd
 usermod -a -G admins $ADMIN_USER
 passwd -l $ADMIN_USER # lock account (AWS workaround; setting passwd reenables)
+
+# copy files from skel-ansible
+su - ${ADMIN_USER} -c "cp -r /etc/skel-${ADMIN_USER}/* /home/${ADMIN_USER}"
 
 # create ansible log directory
 mkdir -p /var/log/ansible

--- a/conf.d/main
+++ b/conf.d/main
@@ -30,7 +30,7 @@ chown $ADMIN_USER:$ADMIN_USER /var/log/ansible
 # add keychain to ~/.bashrc.d
 cat > /home/$ADMIN_USER/.bashrc.d/keychain <<_EOF_
 keychain ~/.ssh/id_rsa
-source ~/.keychain/$HOSTNAME-sh
+source ~/.keychain/\$(hostname)-sh
 _EOF_
 chmod 0755 /home/$ADMIN_USER/.bashrc.d/keychain
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -13,13 +13,10 @@ pip install --upgrade 'pywinrm>=0.1.1'
 
 # create admins group, ansible user and sudo privs
 addgroup --system admins
-adduser --disabled-login --gecos 'ansible user' $ADMIN_USER
+SKEL=/etc/skel-ansible adduser --disabled-login --gecos 'ansible user' $ADMIN_USER
 echo $ADMIN_USER:$ADMIN_PASS | chpasswd
 usermod -a -G admins $ADMIN_USER
 passwd -l $ADMIN_USER # lock account (AWS workaround; setting passwd reenables)
-
-# copy files from skel-ansible
-su - ${ADMIN_USER} -c "cp -r /etc/skel-${ADMIN_USER}/* /home/${ADMIN_USER}"
 
 # create ansible log directory
 mkdir -p /var/log/ansible

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,5 +1,5 @@
-Ansible - An IT automation tool
-=================================
+Ansible® - An IT automation tool
+================================
 
 `Ansible`_ is an IT automation tool. It can configure systems, deploy software, and orchestrate more advanced IT tasks such as continuous deployments or zero downtime rolling updates.
 
@@ -181,6 +181,7 @@ Documentation
 - http://devopsu.com/guides/ansible-ubuntu-debian.html
 - https://github.com/fourkitchens/server-playbooks
 
+Ansible® is a registered trademark of Ansible, Inc. in the United States and other countries.
 
 .. _Ansible: https://docs.ansible.com/ansible/index.html
 .. _Inventory: https://docs.ansible.com/ansible/intro_inventory.html

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -173,6 +173,15 @@ After the TurnKey appliance has been initialized by init.yml, you can then gathe
         "changed": false
     }
 
+MultiUser
+---------
+
+If the Ansible appliance will be used by multiple developers, then you will need to create additional users. To give them the default ansible directory layout, specify the environment varible ``SKEL=/etc/skel-ansible``. If your needs include a different default layout, you may want to modify ``/etc/skel-ansible`` before adding the users.
+
+::
+
+    SKEL=/etc/skel-ansible adduser --gecos '{users full name}' {users account name}
+
 Documentation
 -------------
 - See the latest documentation at https://docs.ansible.com/ansible/index.html
@@ -181,7 +190,7 @@ Documentation
 - http://devopsu.com/guides/ansible-ubuntu-debian.html
 - https://github.com/fourkitchens/server-playbooks
 
-Ansible® is a registered trademark of Ansible, Inc. in the United States and other countries.
+**Ansible®** is a registered trademark of Ansible, Inc. in the United States and other countries.
 
 .. _Ansible: https://docs.ansible.com/ansible/index.html
 .. _Inventory: https://docs.ansible.com/ansible/intro_inventory.html


### PR DESCRIPTION
Some changes I don't want to get lost if the appliance is converted to use PPA repo.
```
* 445572c - (HEAD -> updates-for-15.0, origin/updates-for-15.0) use SKEL=/etc/skel-ansible to copy files (3 months ago) <Dude4Linux>
* 23926f0 - updated README and changelog (3 months ago) <Dude4Linux>
* 08a6aaf - added Trademark statements (3 months ago) <Dude4Linux>
* be40d37 - copy files from skel-ansible (3 months ago) <Dude4Linux>
* 5ed32cf - use $(hostname) for containers (3 months ago) <Dude4Linux>
* adaa0de - bumped Ansible version to 2.5.0 (3 months ago) <Dude4Linux>
```
The ansible version should probably be bumped again to 2.5.4 before the v15.0 final release.